### PR TITLE
Replace deprecated `util._extend` with `Object.assign`

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -1,6 +1,6 @@
 var common   = exports,
     url      = require('url'),
-    extend   = require('util')._extend,
+    extend   = Object.assign,
     required = require('requires-port');
 
 var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,

--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -1,5 +1,5 @@
 var httpProxy = module.exports,
-    extend    = require('util')._extend,
+    extend    = Object.assign,
     parse_url = require('url').parse,
     EE3       = require('eventemitter3'),
     http      = require('http'),


### PR DESCRIPTION
This PR replaces `util._extend` with `Object.assign`.

It prevents the following warning from being emitted with Node.js 22+:
```txt
(node:14132) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
```